### PR TITLE
Remove unused OMP references; add row < maxNumStr check to readinput_

### DIFF
--- a/src/GaKCo.cpp
+++ b/src/GaKCo.cpp
@@ -15,7 +15,6 @@
 #include "shared.h"
 #include "shared.cpp"
 #include <assert.h>
-#include <omp.h>
 #include <thread>
 #include <iostream>
 #include <random>

--- a/src/readInput.cpp
+++ b/src/readInput.cpp
@@ -6,7 +6,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <omp.h>
 
 int * string_replace (char *s, char *d);
 int help2();
@@ -31,7 +30,7 @@ int ** Readinput_(char *filename, char *dictFileName, int *seqLabels, int *seqLe
         int row = 0; //counts rows of the output and line number of the sequence file
         output =  (int **) malloc(maxNumStr * sizeof(int *));
 
-        while (fgets(line, STRMAXLEN, inpfile)) {
+        while (fgets(line, STRMAXLEN, inpfile) && row < maxNumStr) {
             linetemp = (char *) malloc(STRMAXLEN * sizeof(char *));
             strcpy(linetemp, line);
             if (isLabel) {


### PR DESCRIPTION
OpenMP not being used, so removed (should make things easier for Mac users). Added check to make sure row doesn't exceed maxNumStr in readInput method. 